### PR TITLE
Adding progress bars for long operations

### DIFF
--- a/src/org/openstreetmap/josm/plugins/notes/api/util/NotesCapableOsmApi.java
+++ b/src/org/openstreetmap/josm/plugins/notes/api/util/NotesCapableOsmApi.java
@@ -159,14 +159,17 @@ public class NotesCapableOsmApi extends OsmApi {
      * @return List of notes matching the search criteria or empty list if no matches are found
      * @throws OsmTransferException
      */
-    public List<Note> searchNotes(String searchTerm, Integer bugLimit, Integer closedDays) throws OsmTransferException {
+    public List<Note> searchNotes(String searchTerm, Integer bugLimit, Integer closedDays, ProgressMonitor monitor) throws OsmTransferException {
+        if(monitor == null) {
+            monitor = NullProgressMonitor.INSTANCE;
+        }
+        monitor.beginTask("Searching notes");
         if(bugLimit != null && (bugLimit < 1 || bugLimit > NOTE_DOWNLOAD_LIMIT)) {
             throw new IllegalArgumentException("Bug limit must be between 1 and 9999");
         }
         if(closedDays != null && closedDays < -1) {
             throw new IllegalArgumentException("Closed date must be -1 or greater");
         }
-        ProgressMonitor monitor = NullProgressMonitor.INSTANCE;
         String searchTermEncoded = "";
         try {
             searchTermEncoded = URLEncoder.encode(searchTerm, "UTF-8");
@@ -186,8 +189,15 @@ public class NotesCapableOsmApi extends OsmApi {
             urlBuilder.append(closedDays);
         }
         String url = urlBuilder.toString();
+        monitor.worked(1);
+        monitor.indeterminateSubTask("Querying the API for notes");
         String response = sendRequest("GET", url, null, monitor, false, false);
-        return parseNotes(response);
+        monitor.worked(1);
+        monitor.indeterminateSubTask("parsing notes");
+        List<Note> notes = parseNotes(response);
+        monitor.worked(1);
+        monitor.finishTask();
+        return notes;
     }
 	
 	private List<Note> parseNotes(String notesXml) {

--- a/src/org/openstreetmap/josm/plugins/notes/api/util/NotesCapableOsmApi.java
+++ b/src/org/openstreetmap/josm/plugins/notes/api/util/NotesCapableOsmApi.java
@@ -163,7 +163,8 @@ public class NotesCapableOsmApi extends OsmApi {
         if(monitor == null) {
             monitor = NullProgressMonitor.INSTANCE;
         }
-        monitor.beginTask("Searching notes");
+        monitor.beginTask(tr("Searching for notes"), 3);
+        
         if(bugLimit != null && (bugLimit < 1 || bugLimit > NOTE_DOWNLOAD_LIMIT)) {
             throw new IllegalArgumentException("Bug limit must be between 1 and 9999");
         }
@@ -190,13 +191,22 @@ public class NotesCapableOsmApi extends OsmApi {
         }
         String url = urlBuilder.toString();
         monitor.worked(1);
-        monitor.indeterminateSubTask("Querying the API for notes");
-        String response = sendRequest("GET", url, null, monitor, false, false);
-        monitor.worked(1);
-        monitor.indeterminateSubTask("parsing notes");
-        List<Note> notes = parseNotes(response);
-        monitor.worked(1);
-        monitor.finishTask();
+        
+        List<Note> notes = new ArrayList<Note>();
+        try {
+            monitor.indeterminateSubTask(tr("Querying the API for notes"));
+            String response = sendRequest("GET", url, null, monitor, false, false);
+            monitor.worked(1);
+            
+            monitor.indeterminateSubTask(tr("Parsing API response"));
+            notes = parseNotes(response);
+            monitor.worked(1);
+        } catch(Exception e) {
+            Main.error(e);
+            throw new OsmTransferException(e);
+        } finally {
+            monitor.finishTask();
+        }
         return notes;
     }
 	

--- a/src/org/openstreetmap/josm/plugins/notes/gui/NotesDialog.java
+++ b/src/org/openstreetmap/josm/plugins/notes/gui/NotesDialog.java
@@ -97,7 +97,7 @@ public class NotesDialog extends ToggleDialog implements NotesObserver, LayerCha
     private JToggleButton toggleConnectionMode;
     private JTabbedPane tabbedPane = new JTabbedPane();
     private boolean queuePanelVisible = false;
-    private final ActionQueue actionQueue = new ActionQueue();
+    private final ActionQueue actionQueue = new ActionQueue(this);
 
     private boolean buttonLabels = Main.pref.getBoolean(ConfigKeys.NOTES_BUTTON_LABELS);
 

--- a/src/org/openstreetmap/josm/plugins/notes/gui/action/ActionQueue.java
+++ b/src/org/openstreetmap/josm/plugins/notes/gui/action/ActionQueue.java
@@ -52,7 +52,7 @@ public class ActionQueue extends AbstractListModel {
     }
 
     public void processQueue() throws Exception {
-        final QueueProcessTask task = new QueueProcessTask("Processing notes queue");
+        final QueueProcessTask task = new QueueProcessTask(tr("Processing notes queue"));
         task.initParams(queue);
         Main.worker.submit(task);
     }

--- a/src/org/openstreetmap/josm/plugins/notes/gui/action/ActionQueue.java
+++ b/src/org/openstreetmap/josm/plugins/notes/gui/action/ActionQueue.java
@@ -1,14 +1,31 @@
 package org.openstreetmap.josm.plugins.notes.gui.action;
 
+import static org.openstreetmap.josm.tools.I18n.tr;
+
+import java.io.IOException;
 import java.util.LinkedList;
 
 import javax.swing.AbstractListModel;
+import javax.swing.JOptionPane;
+
+import org.openstreetmap.josm.Main;
+import org.openstreetmap.josm.gui.PleaseWaitRunnable;
+import org.openstreetmap.josm.gui.progress.PleaseWaitProgressMonitor;
+import org.openstreetmap.josm.io.OsmTransferException;
+import org.openstreetmap.josm.plugins.notes.gui.NotesDialog;
+import org.xml.sax.SAXException;
 
 public class ActionQueue extends AbstractListModel {
 
 	private static final long serialVersionUID = 1L;
 	
 	private LinkedList<NotesAction> queue = new LinkedList<NotesAction>();
+	
+	private NotesDialog dialog;
+	
+	public ActionQueue(NotesDialog dialog) {
+	    this.dialog = dialog;
+	}
 
     public boolean offer(NotesAction e) {
         boolean result = queue.offer(e);
@@ -35,22 +52,9 @@ public class ActionQueue extends AbstractListModel {
     }
 
     public void processQueue() throws Exception {
-        while(!queue.isEmpty()) {
-            // get the first action, but leave it in queue
-            NotesAction action = queue.peek();
-
-            // execute the action
-            action.execute();
-
-            // notify observers
-            for (NotesActionObserver obs : action.getActionObservers()) {
-                obs.actionPerformed(action);
-            }
-
-            // if no exception has been thrown, remove the action from the queue
-            queue.remove();
-            fireIntervalRemoved(this, 0, 0);
-        }
+        final QueueProcessTask task = new QueueProcessTask("Processing notes queue");
+        task.initParams(queue);
+        Main.worker.submit(task);
     }
 
     public NotesAction getElementAt(int index) {
@@ -59,5 +63,76 @@ public class ActionQueue extends AbstractListModel {
 
     public int getSize() {
         return queue.size();
+    }
+    
+    private class QueueProcessTask extends PleaseWaitRunnable {
+        
+        private boolean isCancelled = false;
+        private boolean isFinished = false;
+        LinkedList<NotesAction> queue;
+        
+        public QueueProcessTask(String title) {
+            super(title);
+        }
+        
+        public void initParams(LinkedList<NotesAction> queue) {
+            this.queue = queue;
+        }
+        
+        @Override
+        protected void realRun() throws SAXException, IOException,
+        OsmTransferException {
+            PleaseWaitProgressMonitor monitor = new PleaseWaitProgressMonitor();
+            monitor.beginTask("Processing notes queue");
+            int notesCount = queue.size();
+            monitor.setTicksCount(notesCount);
+            monitor.setCustomText("0/" + notesCount);
+            int processedCount = 0;
+            
+            try {
+                while(!queue.isEmpty() && !isCancelled) {
+                    NotesAction action = queue.pop();
+                    try {
+                        action.execute();
+                    }
+                    catch(Exception e) {
+                        Main.error("problem executing note action");
+                        Main.error(e, true);
+                        queue.add(action);
+                    }
+                    for (NotesActionObserver obs : action.getActionObservers()) {
+                        obs.actionPerformed(action);
+                    }
+                    fireIntervalRemoved(this, 0, 0);
+                    monitor.worked(1);
+                    monitor.setCustomText(++processedCount + "/" + notesCount);
+                    //Avoid infinite loop in case a note has a persistent upload error
+                    if(processedCount >= notesCount) {
+                        break;
+                    }
+                }
+            }
+            finally {
+                monitor.close();
+                isFinished = true;
+            }
+        }
+        
+        @Override
+        protected void cancel() {
+            Main.info("note queue processing cancelled");
+            isCancelled = true;
+        }
+        
+        @Override
+        protected void finish() {
+            System.out.println("finish method called. queue: " + queue.size());
+            if(queue.size() == 0) {
+                dialog.hideQueuePanel();
+            } else {
+                Main.error("The queue was not 0 after processing!");
+                JOptionPane.showMessageDialog(Main.parent, tr("Not all of your notes were uploaded. Please check the queue panel."));
+            }
+        }
     }
 }

--- a/src/org/openstreetmap/josm/plugins/notes/gui/action/SearchAction.java
+++ b/src/org/openstreetmap/josm/plugins/notes/gui/action/SearchAction.java
@@ -3,19 +3,26 @@ package org.openstreetmap.josm.plugins.notes.gui.action;
 import static org.openstreetmap.josm.tools.I18n.tr;
 
 import java.awt.event.ActionEvent;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
 import javax.swing.JOptionPane;
 
 import org.openstreetmap.josm.Main;
+import org.openstreetmap.josm.gui.PleaseWaitRunnable;
+import org.openstreetmap.josm.gui.progress.PleaseWaitProgressMonitor;
+import org.openstreetmap.josm.gui.progress.ProgressMonitor;
 import org.openstreetmap.josm.gui.widgets.HistoryChangedListener;
+import org.openstreetmap.josm.io.OsmTransferException;
 import org.openstreetmap.josm.plugins.notes.ConfigKeys;
 import org.openstreetmap.josm.plugins.notes.Note;
 import org.openstreetmap.josm.plugins.notes.NotesPlugin;
 import org.openstreetmap.josm.plugins.notes.api.util.NotesCapableOsmApi;
 import org.openstreetmap.josm.plugins.notes.gui.NotesDialog;
 import org.openstreetmap.josm.plugins.notes.gui.dialogs.TextInputDialog;
+import org.xml.sax.SAXException;
 
 public class SearchAction extends NotesAction {
 
@@ -76,14 +83,24 @@ public class SearchAction extends NotesAction {
             daysClosed = -1;
             Main.pref.putInteger(ConfigKeys.NOTES_SEARCH_DAYS_CLOSED, daysClosed);
         }
-        List<Note> searchResults = NotesCapableOsmApi.getNotesApi().searchNotes(searchTerm, noteLimit, daysClosed);
-        System.out.println("search results: " + searchResults.size());
-        plugin.getDataSet().clear();
-        plugin.getDataSet().addAll(searchResults);
-        plugin.updateGui();
-        dialog.setConnectionMode(true);
-        dialog.showQueuePanel();
-        Main.pref.put(ConfigKeys.NOTES_API_OFFLINE, true);
+
+        final NoteSearchTask task = new NoteSearchTask("Searching for notes");
+        task.initParams(searchTerm, noteLimit, daysClosed);
+        Main.worker.submit(task);
+        Main.worker.submit(new Runnable() {
+            @Override
+            public void run() {
+                if (task.isCanceled() || task.isFailed()) return;
+                List<Note> results = task.getFoundNotes();
+                System.out.println("search results: " + results.size());
+                plugin.getDataSet().clear();
+                plugin.getDataSet().addAll(results);
+                plugin.updateGui();
+                dialog.setConnectionMode(true);
+                dialog.showQueuePanel();
+                Main.pref.put(ConfigKeys.NOTES_API_OFFLINE, true);
+            }
+        });
     }
 
     @Override
@@ -97,5 +114,58 @@ public class SearchAction extends NotesAction {
         action.canceled = canceled;
         action.searchTerm = searchTerm;
         return action;
+    }
+
+    private class NoteSearchTask extends PleaseWaitRunnable {
+
+        public NoteSearchTask(String title) {
+            super(title);
+        }
+
+        private String searchTerm;
+        private Integer bugLimit;
+        private Integer closedDays;
+        private List<Note> returnedNotes;
+        Boolean isCancelled = false;
+        Boolean isFailed = false;
+
+        public void initParams(String searchTerm, Integer bugLimit, Integer closedDays) {
+            this.searchTerm = searchTerm;
+            this.bugLimit = bugLimit;
+            this.closedDays = closedDays;
+            returnedNotes = new ArrayList<Note>();
+        }
+
+        @Override
+        protected void cancel() {
+            Main.info("note search cancelled");
+            isCancelled = true;
+        }
+
+        @Override
+        protected void realRun() throws SAXException, IOException,
+        OsmTransferException {
+            ProgressMonitor monitor = new PleaseWaitProgressMonitor();
+            List<Note> noteList = NotesCapableOsmApi.getNotesApi().searchNotes(searchTerm, bugLimit, closedDays, monitor);
+            Main.info("found notes: " + noteList.size());
+            returnedNotes.addAll(noteList);
+        }
+
+        @Override
+        protected void finish() {
+            // TODO Auto-generated method stub
+        }
+
+        public List<Note> getFoundNotes() {
+            return returnedNotes;
+        }
+
+        public Boolean isCanceled() {
+            return isCancelled;
+        }
+
+        public Boolean isFailed() {
+            return isFailed;
+        }
     }
 }

--- a/src/org/openstreetmap/josm/plugins/notes/gui/action/SearchAction.java
+++ b/src/org/openstreetmap/josm/plugins/notes/gui/action/SearchAction.java
@@ -13,7 +13,6 @@ import javax.swing.JOptionPane;
 import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.gui.PleaseWaitRunnable;
 import org.openstreetmap.josm.gui.progress.PleaseWaitProgressMonitor;
-import org.openstreetmap.josm.gui.progress.ProgressMonitor;
 import org.openstreetmap.josm.gui.widgets.HistoryChangedListener;
 import org.openstreetmap.josm.io.OsmTransferException;
 import org.openstreetmap.josm.plugins.notes.ConfigKeys;

--- a/src/org/openstreetmap/josm/plugins/notes/gui/action/SearchAction.java
+++ b/src/org/openstreetmap/josm/plugins/notes/gui/action/SearchAction.java
@@ -145,10 +145,12 @@ public class SearchAction extends NotesAction {
         @Override
         protected void realRun() throws SAXException, IOException,
         OsmTransferException {
-            ProgressMonitor monitor = new PleaseWaitProgressMonitor();
+            PleaseWaitProgressMonitor monitor = new PleaseWaitProgressMonitor();
             List<Note> noteList = NotesCapableOsmApi.getNotesApi().searchNotes(searchTerm, bugLimit, closedDays, monitor);
             Main.info("found notes: " + noteList.size());
             returnedNotes.addAll(noteList);
+            //shouldn't be needed because the API calls finishTask but apparently the PleaseWaitProgressMonitor is buggy
+            monitor.close();
         }
 
         @Override

--- a/src/org/openstreetmap/josm/plugins/notes/gui/action/ToggleConnectionModeAction.java
+++ b/src/org/openstreetmap/josm/plugins/notes/gui/action/ToggleConnectionModeAction.java
@@ -71,9 +71,6 @@ public class ToggleConnectionModeAction extends AbstractAction {
                 try {
                     actionQueue.processQueue();
 
-                    // toggle queue panel visibility, if now error occurred
-                    dialog.hideQueuePanel();
-
                     // refresh, if the api is enabled
                     if(!Main.pref.getBoolean(ConfigKeys.NOTES_API_DISABLED)) {
                         plugin.updateData();


### PR DESCRIPTION
Before, it was running these things in the main UI thread and locking up JOSM while they were in progress. Now tasks are submitted to the main worker thread to be executed sequentially and with appropriate user feedback.
